### PR TITLE
Add set timeout methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,12 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: leafo/gh-actions-lua@v10
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -29,6 +25,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     services:
       postgres:
         image: postgres:14.3
@@ -47,33 +45,22 @@ jobs:
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
+          - "5.1."
+          - "5.2."
+          - "5.3."
+          - "5.4."
+          - "lj-v2.1"
     steps:
+    -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
     -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8.0.0
-      with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
-    -
-      name: Update Apt Packages
-      run: |
-        sudo apt-get update
-    -
-      name: Install Required Packages
-      run: |
-        sudo apt-get install libtls-dev lcov -y
     -
       name: Install Tools
       run: |
@@ -87,7 +74,7 @@ jobs:
     -
       name: Run Test
       env:
-        PGHOST: 127.0.0.1
+        PGHOST: postgres
         PGPORT: 5432
         PGUSER: postgres
         PGPASSWORD: postgres

--- a/lib/connection.lua
+++ b/lib/connection.lua
@@ -144,6 +144,21 @@ function Connection:init(conninfo)
     end
 end
 
+--- set_recv_timeout
+--- @param sec number
+--- @return boolean ok
+--- @return any err
+function Connection:set_recv_timeout(sec)
+    assert(type(sec) == 'number' and sec >= 0, 'sec must be a unsigned number')
+
+    if not self.sock then
+        return false, errorf('connection is closed')
+    end
+
+    local _, err = self.sock:rcvtimeo(sec)
+    return err == nil, err
+end
+
 --- startup
 --- @private
 --- @return boolean ok

--- a/lib/connection.lua
+++ b/lib/connection.lua
@@ -159,6 +159,21 @@ function Connection:set_recv_timeout(sec)
     return err == nil, err
 end
 
+--- set_send_timeout
+--- @param sec number
+--- @return boolean ok
+--- @return any err
+function Connection:set_send_timeout(sec)
+    assert(type(sec) == 'number' and sec >= 0, 'sec must be a unsigned number')
+
+    if not self.sock then
+        return false, errorf('connection is closed')
+    end
+
+    local _, err = self.sock:sndtimeo(sec)
+    return err == nil, err
+end
+
 --- startup
 --- @private
 --- @return boolean ok

--- a/test/connection_test.lua
+++ b/test/connection_test.lua
@@ -171,3 +171,24 @@ function testcase.set_recv_timeout()
     assert(c:close())
 end
 
+function testcase.set_send_timeout()
+    local c = assert(new_connection())
+
+    -- test that set send timeout
+    local ok, err = c:set_send_timeout(5)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that set send timeout with zero value
+    ok, err = c:set_send_timeout(0)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that set send timeout with float value
+    ok, err = c:set_send_timeout(1.5)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- NOTE: It is difficult to test that send timeout works.
+end
+

--- a/test/connection_test.lua
+++ b/test/connection_test.lua
@@ -142,3 +142,32 @@ function testcase.next()
     assert.is_nil(timeout)
 end
 
+function testcase.set_recv_timeout()
+    local c = assert(new_connection())
+
+    -- test that set recv timeout
+    local ok, err = c:set_recv_timeout(5)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that set recv timeout with zero value
+    ok, err = c:set_recv_timeout(0)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that set recv timeout with float value
+    ok, err = c:set_recv_timeout(1.5)
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that recv timeout works
+    local res, timeout
+    res, err, timeout = c:query('SELECT pg_sleep(2)')
+    assert.is_nil(res)
+    assert.is_nil(err)
+    assert.is_true(timeout)
+
+    -- after timeout, the connection should be closed manually
+    assert(c:close())
+end
+


### PR DESCRIPTION
This pull request introduces improvements to both the codebase and the CI workflow. The main changes are the addition of new timeout control methods to the `Connection` class, comprehensive tests for these methods, and significant simplification and modernization of the GitHub Actions workflow for testing.

**Enhancements to Connection timeout handling:**

* Added `set_recv_timeout` and `set_send_timeout` methods to the `Connection` class, allowing users to configure receive and send timeouts on the socket. These methods include input validation and proper error handling.

* Added thorough tests for the new timeout methods in `test/connection_test.lua`, covering normal, zero, and float values, as well as actual timeout scenarios.

**Continuous Integration workflow improvements:**

* Updated the GitHub Actions workflow (`.github/workflows/test.yml`) to use a pre-built Docker container (`ghcr.io/mah0x211/lua-ci:latest`) for both `luacheck` and `test` jobs, removing the need for manual Lua and Luarocks setup steps. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R12-L21) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R28-R29)

* Changed the Lua version matrix to use new version identifiers and added a step to switch Lua versions using `lenv`.

* Updated the test job's Postgres host configuration to use the service name (`postgres`) instead of `127.0.0.1`, ensuring proper connectivity within the containerized environment.