### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest
@@ -45,11 +46,11 @@ jobs:
     strategy:
       matrix:
         lua-version:
-          - "5.1."
-          - "5.2."
-          - "5.3."
-          - "5.4."
-          - "lj-v2.1"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
     -
       name: Switch Lua Version

--- a/rockspecs/postgres-dev-1.rockspec
+++ b/rockspecs/postgres-dev-1.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 dependencies = {
     "lua >= 5.1",
-    "base64mix >= 1.0.1",
+    "base64mix >= 1.1.2",
     "denque >= 0.5.1",
     "error >= 0.12.0",
     "hmac >= 0.3.0",
@@ -28,7 +28,7 @@ dependencies = {
     "yyjson >= 0.5.1",
 }
 build_dependencies = {
-    "luarocks-build-hooks",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = 'hooks',
@@ -86,12 +86,30 @@ build = {
         ["postgres.rows"] = "lib/rows.lua",
         ["postgres.scram"] = "lib/scram.lua",
         -- C modules
-        ["postgres.htonl"] = "src/htonl.c",
-        ["postgres.htons"] = "src/htons.c",
-        ["postgres.md5pswd"] = "src/md5pswd.c",
-        ["postgres.ntohl"] = "src/ntohl.c",
-        ["postgres.ntohs"] = "src/ntohs.c",
-        ["postgres.strxor"] = "src/strxor.c",
+        ["postgres.htonl"] = {
+            sources = { "src/htonl.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
+        ["postgres.htons"] = {
+            sources = { "src/htons.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
+        ["postgres.md5pswd"] = {
+            sources = { "src/md5pswd.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
+        ["postgres.ntohl"] = {
+            sources = { "src/ntohl.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
+        ["postgres.ntohs"] = {
+            sources = { "src/ntohs.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
+        ["postgres.strxor"] = {
+            sources = { "src/strxor.c" },
+            incdirs = { "$(DEP_LAUXHLIB_INCDIR)" },
+        },
         ["postgres.unpack"] = "src/unpack.c",
     },
 }

--- a/src/htonl.c
+++ b/src/htonl.c
@@ -20,9 +20,12 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <arpa/inet.h>
-// lua
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
 
 static int htonl_lua(lua_State *L)
 {

--- a/src/htons.c
+++ b/src/htons.c
@@ -20,9 +20,12 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <arpa/inet.h>
-// lua
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
 
 static int htons_lua(lua_State *L)
 {

--- a/src/md5pswd.c
+++ b/src/md5pswd.c
@@ -35,6 +35,7 @@
  * compile-time configuration.
  */
 
+// system
 #include <string.h>
 
 /* Any 32-bit or wider unsigned integer data type will do */
@@ -313,7 +314,10 @@ static void MD5_Final(unsigned char *result, MD5_CTX *ctx)
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
 
 static int md5pswd_lua(lua_State *L)
 {

--- a/src/ntohl.c
+++ b/src/ntohl.c
@@ -20,9 +20,12 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <arpa/inet.h>
-// lua
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
 
 static int ntohl_lua(lua_State *L)
 {

--- a/src/ntohs.c
+++ b/src/ntohs.c
@@ -20,9 +20,12 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <arpa/inet.h>
-// lua
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
 
 static int ntohs_lua(lua_State *L)
 {

--- a/src/strxor.c
+++ b/src/strxor.c
@@ -20,7 +20,10 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
+// depend
 #include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
 
 static int strxor_lua(lua_State *L)
 {

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -20,12 +20,13 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
+// lua
+#include <lauxlib.h>
+// system
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <inttypes.h>
 #include <string.h>
-// lua
-#include "lauxlib.h"
 
 /**
  * Unpack data string with format string.


### PR DESCRIPTION
This pull request updates dependencies, improves the build configuration for C modules, and refines the include order in several C source files to clarify dependencies and improve maintainability. The most significant changes are grouped below.

**Build and Dependency Updates:**

* Updated dependencies in `rockspecs/postgres-dev-1.rockspec`: bumped `base64mix` to `>= 1.1.2` and `luarocks-build-hooks` to `>= 0.8.0` to ensure compatibility with newer versions. [[1]](diffhunk://#diff-919c5f3c51bbbab4590988a55aebca9cb43541ddf5d00122a927ab29085e55acL15-R15) [[2]](diffhunk://#diff-919c5f3c51bbbab4590988a55aebca9cb43541ddf5d00122a927ab29085e55acL31-R31)
* Changed the build configuration for C modules in `rockspecs/postgres-dev-1.rockspec` to specify sources and include directories explicitly for each module, improving clarity and flexibility for dependency management.

**CI Workflow Improvements:**

* Modified `.github/workflows/test.yml` to make the `test` job depend on `luacheck`, and updated the Lua version matrix to specify `:latest` tags, ensuring the most recent images are used in CI runs. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R27) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L48-R53)

**C Source Code Refactoring:**

* Standardized the include order in C modules (`src/htonl.c`, `src/htons.c`, `src/ntohl.c`, `src/ntohs.c`, `src/strxor.c`, `src/unpack.c`, `src/md5pswd.c`) by including dependency headers (such as `lauxhlib.h`) before system and Lua headers, improving code readability and maintainability. [[1]](diffhunk://#diff-f45dec5b95aea111e77b1ca8ed077e908a5259d044483e9427bbf46de8744b96L23-R28) [[2]](diffhunk://#diff-ec0d4bb9984131ebe79f5108ac458a82d6437dfcba963ed4bd7859d46fb8bbf4L23-R28) [[3]](diffhunk://#diff-4ea81bd0906ab640ebbef060382a1fe1194abcf4d28cd97630f35cacc7fce663L23-R28) [[4]](diffhunk://#diff-54916b57241e7e479638e7016d74b03cf26b02ee63c2b2f1f931273d7bfef5d2L23-R28) [[5]](diffhunk://#diff-9f1cc947a35a206ab42b7dc482749b395c01f23f39387fdca587a434c4138bd2R23-R26) [[6]](diffhunk://#diff-21b4d18dfc47e3506987bf6223996619dfe26e2ab99c8a8e86ba32c79c240c57R23-L28) [[7]](diffhunk://#diff-a01a6c49adb352cf240a67765f7eca5fbc797210e2d693c66580a41d4ab6eed0R38) [[8]](diffhunk://#diff-a01a6c49adb352cf240a67765f7eca5fbc797210e2d693c66580a41d4ab6eed0R317-R320)